### PR TITLE
remove debug env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM cheggwpt/php7-office:1.1.6
 MAINTAINER jgilley@chegg.com
 
 # Statsd Liberato ENVs
-ENV DEBUG 1
 ENV librato_version 2.0.4
 ENV nodejs_version 6.9.5-r0
 ENV statsd_version master


### PR DESCRIPTION
to reduce the statsd thingy logs

I hope this is the right way - will do another PR against https://github.com/CheggWPTdocker/wpt-backend/blob/master/Dockerfile if it is.

I'd like to get rid of these:
```
17 Aug 13:21:51 - DEBUG: Sending Payload: {"time":1502976110,"tags":{"host":"1c544c5fbe99"},"measurements":[{"name":"wpt-api.development.users.guest","value":0,"tags":{"source":"env"}}]}
2017/08/17 13:21:51 Current: Collected 0 measurements, 0 profiles, 0 summary profiles, 0 exceptions since startup.
17 Aug 13:22:01 - DEBUG: Sending Payload: {"time":1502976120,"tags":{"host":"1c544c5fbe99"},"measurements":[{"name":"wpt-api.development.users.guest","value":0,"tags":{"source":"env"}}]}
```