### PR TITLE
Fix node release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER jgilley@chegg.com
 
 # Statsd Liberato ENVs
 ENV librato_version 2.0.4
-ENV nodejs_version 6.9.5-r0
+ENV nodejs_version 6.9.5-r1
 ENV statsd_version master
 
 # Tideways ENVs

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME = cheggwpt/wpt-worker
-VERSION = 1.1.6
+VERSION = 1.1.7
 
 .PHONY: all build test tag_latest release ssh
 


### PR DESCRIPTION
Basically a too tight node restraint.  

- changed 6.9.5-r0 to 6.9.5-r1
- incremented makefile tag version to current in wild version

This does not require an entire tree build.

