### PR TITLE
Update Librato backend to 2.0.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM cheggwpt/php7-office:1.1.6
 MAINTAINER jgilley@chegg.com
 
 # Statsd Liberato ENVs
-ENV librato_version 2.0.4
+ENV librato_version 2.0.14
 ENV nodejs_version 6.9.5-r1
 ENV statsd_version master
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME = cheggwpt/wpt-worker
-VERSION = 1.1.8
+VERSION = 1.1.9
 
 .PHONY: all build test tag_latest release ssh
 


### PR DESCRIPTION
Ok, when I was investigating this I was referring to the 2.0.14 source, overlooking that the dockerfiles are built with 2.0.4.  

This issue was referenced https://github.com/librato/statsd-librato-backend/issues/87 and fixed with 2.0.11.  I reviewed the other releases and upgrading fully to 2.0.14 seems harmless enough.